### PR TITLE
feat: Add Get Payment Method endpoint

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -62,7 +62,7 @@ https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/rest-api
 ### Payment Methods
 
 - [ ] [GET /v3/brokerage/payment_methods - List Payment Methods](https://docs.cdp.coinbase.com/api-reference/advanced-trade-api/rest-api/payment-methods/list-payment-methods)
-- [ ] [GET /v3/brokerage/payment_methods/{payment_method_id} - Get Payment Method](https://docs.cdp.coinbase.com/api-reference/advanced-trade-api/rest-api/payment-methods/get-payment-method)
+- [x] [GET /v3/brokerage/payment_methods/{payment_method_id} - Get Payment Method](https://docs.cdp.coinbase.com/api-reference/advanced-trade-api/rest-api/payment-methods/get-payment-method)
 
 ### Data API
 

--- a/lib/advanced_trade.dart
+++ b/lib/advanced_trade.dart
@@ -35,6 +35,8 @@ export 'src/models/volume_breakdown.dart';
 export 'src/rest/accounts.dart';
 export 'src/rest/data.dart';
 export 'src/rest/fees.dart';
+export 'src/models/payment_method.dart';
+export 'src/rest/payment_methods.dart';
 export 'src/rest/orders/fills.dart';
 export 'src/rest/orders/orders.dart';
 export 'src/rest/portfolios.dart';

--- a/lib/src/models/payment_method.dart
+++ b/lib/src/models/payment_method.dart
@@ -1,0 +1,71 @@
+/// Represents a payment method on Coinbase.
+class PaymentMethod {
+  /// Unique identifier for the payment method.
+  final String? id;
+
+  /// Type of payment method (e.g., "ACH", "WIRE").
+  final String? type;
+
+  /// Name of the payment method.
+  final String? name;
+
+  /// Currency of the payment method.
+  final String? currency;
+
+  /// Whether the payment method is verified.
+  final bool? verified;
+
+  /// Whether the payment method can be used to buy.
+  final bool? allowBuy;
+
+  /// Whether the payment method can be used to sell.
+  final bool? allowSell;
+
+  /// Whether the payment method can be used for deposits.
+  final bool? allowDeposit;
+
+  /// Whether the payment method can be used for withdrawals.
+  final bool? allowWithdraw;
+
+  /// When the payment method was created.
+  final DateTime? createdAt;
+
+  /// When the payment method was last updated.
+  final DateTime? updatedAt;
+
+  /// Creates a new [PaymentMethod].
+  PaymentMethod({
+    this.id,
+    this.type,
+    this.name,
+    this.currency,
+    this.verified,
+    this.allowBuy,
+    this.allowSell,
+    this.allowDeposit,
+    this.allowWithdraw,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  /// Creates a [PaymentMethod] from a JSON object.
+  factory PaymentMethod.fromCBJson(Map<String, dynamic> json) {
+    return PaymentMethod(
+      id: json['id'],
+      type: json['type'],
+      name: json['name'],
+      currency: json['currency'],
+      verified: json['verified'],
+      allowBuy: json['allow_buy'],
+      allowSell: json['allow_sell'],
+      allowDeposit: json['allow_deposit'],
+      allowWithdraw: json['allow_withdraw'],
+      createdAt: json['created_at'] != null
+          ? DateTime.parse(json['created_at'])
+          : null,
+      updatedAt: json['updated_at'] != null
+          ? DateTime.parse(json['updated_at'])
+          : null,
+    );
+  }
+}

--- a/lib/src/rest/payment_methods.dart
+++ b/lib/src/rest/payment_methods.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+
+import 'package:coinbase_cloud_advanced_trade_client/src/models/credential.dart';
+import 'package:coinbase_cloud_advanced_trade_client/src/models/error.dart';
+import 'package:coinbase_cloud_advanced_trade_client/src/models/payment_method.dart';
+import 'package:coinbase_cloud_advanced_trade_client/src/services/network.dart';
+import 'package:http/http.dart' as http;
+
+/// Gets a single payment method for the current user.
+///
+/// GET /api/v3/brokerage/payment_methods/{payment_method_id}
+/// https://docs.cdp.coinbase.com/api-reference/advanced-trade-api/rest-api/payment-methods/get-payment-method
+///
+/// This function makes a GET request to the /payment_methods/{payment_method_id} endpoint of the
+/// Coinbase Advanced Trade API.
+///
+/// [paymentMethodId] - The ID of the payment method to be returned.
+/// [credential] - The user's API credentials.
+/// [isSandbox] - Whether to use the sandbox environment.
+///
+/// Returns a [PaymentMethod] object.
+Future<PaymentMethod> getPaymentMethod(
+    {required String paymentMethodId,
+    http.Client? client,
+    required Credential credential,
+    bool isSandbox = false}) async {
+  http.Response response = await getAuthorized(
+      '/payment_methods/$paymentMethodId',
+      client: client,
+      credential: credential,
+      isSandbox: isSandbox);
+
+  if (response.statusCode == 200) {
+    var jsonResponse = jsonDecode(response.body);
+    var jsonPaymentMethod = jsonResponse['payment_method'];
+
+    return PaymentMethod.fromCBJson(jsonPaymentMethod);
+  } else {
+    throw CoinbaseException(
+        'Failed to get payment method', response.statusCode, response.body);
+  }
+}

--- a/test/rest/payment_methods/get_payment_method.json
+++ b/test/rest/payment_methods/get_payment_method.json
@@ -1,0 +1,15 @@
+{
+  "payment_method": {
+    "id": "8bfc20d7-f7c6-4422-bf07-8243ca4169fe",
+    "type": "ACH",
+    "name": "ALLY BANK ******1234",
+    "currency": "USD",
+    "verified": true,
+    "allow_buy": true,
+    "allow_sell": true,
+    "allow_deposit": true,
+    "allow_withdraw": true,
+    "created_at": "2021-05-31T09:59:59Z",
+    "updated_at": "2021-05-31T09:59:59Z"
+  }
+}

--- a/test/rest/payment_methods/payment_methods_test.dart
+++ b/test/rest/payment_methods/payment_methods_test.dart
@@ -1,0 +1,42 @@
+import 'package:coinbase_cloud_advanced_trade_client/advanced_trade.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+import '../../test_constants.dart' as constants;
+import '../../tools.dart';
+
+void main() {
+  group('Payment Methods REST', () {
+    test('getPaymentMethod returns a single payment method', () async {
+      String jsonResponse =
+          await getJsonFromFile('rest/payment_methods/get_payment_method.json');
+
+      final client = MockClient((request) async {
+        return http.Response(jsonResponse, 200);
+      });
+
+      Credential credential = Credential(
+          apiKeyName: 'testApiKey', privateKeyPEM: constants.privateKeyPEM);
+
+      PaymentMethod paymentMethod = await getPaymentMethod(
+          paymentMethodId: '8bfc20d7-f7c6-4422-bf07-8243ca4169fe',
+          client: client,
+          credential: credential);
+
+      expect(paymentMethod.id, '8bfc20d7-f7c6-4422-bf07-8243ca4169fe');
+      expect(paymentMethod.type, 'ACH');
+      expect(paymentMethod.name, 'ALLY BANK ******1234');
+      expect(paymentMethod.currency, 'USD');
+      expect(paymentMethod.verified, true);
+      expect(paymentMethod.allowBuy, true);
+      expect(paymentMethod.allowSell, true);
+      expect(paymentMethod.allowDeposit, true);
+      expect(paymentMethod.allowWithdraw, true);
+      expect(paymentMethod.createdAt?.toIso8601String(),
+          DateTime.parse('2021-05-31T09:59:59Z').toIso8601String());
+      expect(paymentMethod.updatedAt?.toIso8601String(),
+          DateTime.parse('2021-05-31T09:59:59Z').toIso8601String());
+    });
+  });
+}


### PR DESCRIPTION
Added a PaymentMethod model, the getPaymentMethod REST function, and corresponding mock tests to support the Get Payment Method endpoint from the Coinbase Advanced Trade API.

---
*PR created automatically by Jules for task [3797566943462135121](https://jules.google.com/task/3797566943462135121) started by @JaysonBH*